### PR TITLE
Fixed about getting current room's id.

### DIFF
--- a/chatwork_omikuji.js
+++ b/chatwork_omikuji.js
@@ -1,4 +1,4 @@
-javascript:(function() {
+javascript: (function () {
   function getReviewers() {
     function shuffle(e) {
       for (var r, t, n = e.length; n;) t = Math.floor(Math.random() * n--), r = e[n], e[n] = e[t], e[t] = r;
@@ -6,14 +6,17 @@ javascript:(function() {
     }
     function getMembersByName(name) {
       return memberData = Object.keys(RL.rooms)
-        .map(k=>RL.rooms[k])
-        .find(r=>r._name===roomName)
+        .map(k => RL.rooms[k])
+        .find(r => r._name === roomName)
         .member_dat;
     }
     function getMembersById(id) {
       return RL.rooms[id].member_dat;
     }
-    const names = Object.keys(getMembersById(RL.focused_room_id))
+    function getActiveRoomId() {
+      return document.getElementById("_roomTitle").getElementsByTagName("div")[0].dataset["roomid"];
+    }
+    const names = Object.keys(getMembersById(getActiveRoomId()))
       .map(id => ({ name: />([^<]*)</.exec(CW.getName(id))[1], id }));
 
     return shuffle(names);
@@ -21,11 +24,10 @@ javascript:(function() {
   let reviewers = getReviewers();
   let target = reviewers[0];
   let result = "[To:" + target.id + "]" + target.name + "、君に決めた!\n";
-  result += "[code]", reviewers.forEach(function(e) {
-      result += e.name + ", "
+  result += "[code]", reviewers.forEach(function (e) {
+    result += e.name + ", "
   });
   result += "[/code]\n";
   document.getElementById("_chatText").value =
     document.getElementById("_chatText").value + "\n" + result + "\n";
 })();
-

--- a/chatwork_omikuji.js
+++ b/chatwork_omikuji.js
@@ -14,7 +14,7 @@ javascript: (function () {
       return RL.rooms[id].member_dat;
     }
     function getActiveRoomId() {
-      return document.getElementById("_roomTitle").getElementsByTagName("div")[0].dataset["roomid"];
+      return document.querySelector('[data-roomid]').dataset.roomid;
     }
     const names = Object.keys(getMembersById(getActiveRoomId()))
       .map(id => ({ name: />([^<]*)</.exec(CW.getName(id))[1], id }));


### PR DESCRIPTION
現在のChatworkのおみくじがうまく動かないようになった模様です・・・。
具体的には、アクティビティになっているチャットルームのIDが取得できていませんでした。
そこで、HTMLからアクティブなチャットルームのIDを取得するように変更しました。

Current Omikuji function doesn't work for something changed about getting current room's id.
So, I changed about getting current room id by finding it in HTML.